### PR TITLE
Fix environment getter bug

### DIFF
--- a/game_manager.gd
+++ b/game_manager.gd
@@ -188,7 +188,7 @@ func add_unlocked_plant(plant_name: String):
 		_game_state.unlocked_plants.append(plant_name)
 
 func get_current_env():
-	return 0
+       return _game_state.current_environment
 
 func get_greylist():
 	return _game_state.greylist


### PR DESCRIPTION
## Summary
- fix GameManager.get_current_env to actually return the saved current environment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f780102188329b635f1c874ecce21